### PR TITLE
Allow for adding tiered multiblocks that do not have their own recipe categories

### DIFF
--- a/docs/ADDING_TIERED_MULTIBLOCKS.md
+++ b/docs/ADDING_TIERED_MULTIBLOCKS.md
@@ -55,6 +55,9 @@ function createPyrolyseTier(event, id, coilBlockId, maxBaseEu, multiplier, euCos
 		// Defines the additional workstations to display for this tier (aside from the machine block itself)
 		// You can provide as many workstations as you would like for your tier
 		// Here this just mimics what MI does with the EBF by adding the coil block as a workstation
+		// Do note that when using the non-standalone functions to create a machine, the IDs added to this workstation
+		//  list are the IDs of the machines to add this machine to its workstations. This is the same as how the batch
+		//  multiblock registering works for workstations.
 		(workstations) => workstations.add(coilBlockId),
 		// The max EU/t recipe the tier can run
 		// Optional: defaults to 128
@@ -74,10 +77,14 @@ MITweaksMachineEvents.registerTieredMultiblocks((event) =>
 	const cupronickel = createPyrolyseTier(event, "pyrolyse_oven_cupronickel", "modern_industrialization:cupronickel_coil", 32, 1, 1);
 	const kanthal = createPyrolyseTier(event, "pyrolyse_oven_kanthal", "modern_industrialization:kanthal_coil", 128, 10, 0.5);
 	// Register the machine
-	// You can also use `event.steam(...)` for a steam machine
-	event.electric(
+	// You can also use `event.steamStandalone(...)` for a steam machine
+	// If you want to make a machine that uses existing recipe types and don't want to make your own recipe
+	//  categories, you can use `event.electric(...)` or `event.steam(...)` instead. When using these functions, you
+	//  must exclude the REI params.
+	event.electricStandalone(
 		// English name, internal name
 		"Pyrolyse Oven", "pyrolyse_oven",
+		// The tiers for your machine
 		(tiers) => tiers.add(cupronickel).add(kanthal),
 		// REI progress bar
 		event.progressBar(77, 33, "arrow"),

--- a/src/main/java/net/swedz/mi_tweaks/compat/kubejs/machine/RegisterTieredMultiblocksEventJS.java
+++ b/src/main/java/net/swedz/mi_tweaks/compat/kubejs/machine/RegisterTieredMultiblocksEventJS.java
@@ -71,6 +71,75 @@ public final class RegisterTieredMultiblocksEventJS implements KubeEvent, ShapeT
 			
 			Consumer<TierAdder> tiers,
 			
+			String controllerCasingId, String overlayFolder, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+			
+			BiFunction<BEP, CustomMultiblockTier[], MachineBlockEntity> factory
+	)
+	{
+		var machineId = MITweaks.machineId(name);
+		var casing = MachineCasings.get(controllerCasingId);
+		
+		var tierAdder = new TierAdder();
+		tiers.accept(tierAdder);
+		var multiblockTiers = tierAdder.get();
+		
+		var builder = hook.builder(name, englishName, (bep) -> factory.apply(bep, multiblockTiers.toArray(CustomMultiblockTier[]::new)))
+				.builtinModel(casing, overlayFolder, (b) -> b.front(frontOverlay).top(topOverlay).side(sideOverlay))
+				.registerMachine();
+		
+		for(var tier : multiblockTiers)
+		{
+			ReiMachineRecipes.registerMultiblockShape(machineId, tier.shape(), tier.id());
+			
+			for(var workstation : tier.getWorkstations())
+			{
+				builder.registerAsWorkstationFor(workstation);
+			}
+		}
+	}
+	
+	public void steam(
+			String englishName, String name,
+			
+			Consumer<TierAdder> tiers,
+			
+			String controllerCasingId, String overlayFolder, boolean frontOverlay, boolean topOverlay, boolean sideOverlay
+	)
+	{
+		this.create(
+				englishName, name,
+				tiers,
+				controllerCasingId, overlayFolder, frontOverlay, topOverlay, sideOverlay,
+				(bep, t) -> new SteamTieredCraftingMultiblockBlockEntity(
+						bep, MITweaks.machineId(name), t,
+						OverclockComponent.getDefaultCatalysts()
+				)
+		);
+	}
+	
+	public void electric(
+			String englishName, String name,
+			
+			Consumer<TierAdder> tiers,
+			
+			String controllerCasingId, String overlayFolder, boolean frontOverlay, boolean topOverlay, boolean sideOverlay
+	)
+	{
+		this.create(
+				englishName, name,
+				tiers,
+				controllerCasingId, overlayFolder, frontOverlay, topOverlay, sideOverlay,
+				(bep, t) -> new ElectricTieredCraftingMultiblockBlockEntity(
+						bep, MITweaks.machineId(name), t
+				)
+		);
+	}
+	
+	private void createStandalone(
+			String englishName, String name,
+			
+			Consumer<TierAdder> tiers,
+			
 			ProgressBar.Params progressBar,
 			
 			Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
@@ -121,7 +190,7 @@ public final class RegisterTieredMultiblocksEventJS implements KubeEvent, ShapeT
 		ReiMachineRecipes.registerMachineClickArea(machineId, progressBar.toRectangle());
 	}
 	
-	public void steam(
+	public void steamStandalone(
 			String englishName, String name,
 			
 			Consumer<TierAdder> tiers,
@@ -134,7 +203,7 @@ public final class RegisterTieredMultiblocksEventJS implements KubeEvent, ShapeT
 			String controllerCasingId, String overlayFolder, boolean frontOverlay, boolean topOverlay, boolean sideOverlay
 	)
 	{
-		this.create(
+		this.createStandalone(
 				englishName, name,
 				tiers,
 				progressBar,
@@ -149,7 +218,7 @@ public final class RegisterTieredMultiblocksEventJS implements KubeEvent, ShapeT
 		);
 	}
 	
-	public void electric(
+	public void electricStandalone(
 			String englishName, String name,
 			
 			Consumer<TierAdder> tiers,
@@ -162,7 +231,7 @@ public final class RegisterTieredMultiblocksEventJS implements KubeEvent, ShapeT
 			String controllerCasingId, String overlayFolder, boolean frontOverlay, boolean topOverlay, boolean sideOverlay
 	)
 	{
-		this.create(
+		this.createStandalone(
 				englishName, name,
 				tiers,
 				progressBar,


### PR DESCRIPTION
This introduces some breaking changes to the `MITweaksMachineEvents.registerTieredMultiblocks` event.

These two functions were renamed and retained their prior functionality:
- `event.electric(...)` -> `event.electricStandalone`
- `event.steam(...)` -> `event.steamStandalone`

And two new functions were added to allow for tiered multiblocks that rely on existing recipe categories:
- `event.electric(...)`
- `event.steam(...)`